### PR TITLE
Fix: Update README file extension in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(
     package_data={'pycorn': ['docs/*.*']},
     license='GNU General Public License v2 (GPLv2)',
     description='A script to extract data from UNICORN result (res) files',
-    long_description=open('README.rst').read(),
+    long_description=open('README.md').read(),
     url='https://github.com/ronald-jaepel/PyCORN',
 )


### PR DESCRIPTION
## Problem
The `setup.py` configuration references an incorrect README file extension, causing installation to fail.

## Solution
Updated the README file extension to `.md` in `setup.py`.

## Changes
- setup.py

## Testing
- Verified package installs correctly with `pip install -e .`

Resolves #2